### PR TITLE
expose Text.XkbCommon.InternalTypes

### DIFF
--- a/Text/XkbCommon/InternalTypes.hsc
+++ b/Text/XkbCommon/InternalTypes.hsc
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP, EmptyDataDecls, GeneralizedNewtypeDeriving, TemplateHaskell #-}
+-- | This module is intended to be used only when interoperating with other C libraries.
+-- For other usecases, `Text.XkbCommon.Types` is probably preferable.
 module Text.XkbCommon.InternalTypes
    ( Context, CContext, InternalContext, toContext, fromContext, withContext,
      ContextFlags(..), defaultFlags,

--- a/xkbcommon.cabal
+++ b/xkbcommon.cabal
@@ -122,13 +122,13 @@ library
     Text.XkbCommon.ModList,
     Text.XkbCommon.Constants,
     Text.XkbCommon.Types,
+    Text.XkbCommon.InternalTypes,
     Text.XkbCommon.Context,
     Text.XkbCommon.Keymap,
     Text.XkbCommon.KeyboardState,
     Text.XkbCommon.Keysym
   other-modules:
-    Text.XkbCommon.ParseDefines,
-    Text.XkbCommon.InternalTypes
+    Text.XkbCommon.ParseDefines
   -- other-modules:
   build-depends:       base <5, transformers, storable-record, process, cpphs, template-haskell, text, bytestring, data-flags, filepath
   -- build-tools:         c2hs


### PR DESCRIPTION
internal types need to be exposed in order to make interfaces to other C libraries that use `xkb_state *`s and `xkb_keymap *`s (e.g. https://github.com/dlahoti/haskell-wlc)