### PR TITLE
Add setup-depends

### DIFF
--- a/xkbcommon.cabal
+++ b/xkbcommon.cabal
@@ -190,3 +190,6 @@ Test-Suite stringcomp
   other-modules: Common
   main-is: stringcomp.hs
   build-depends : base, xkbcommon
+
+custom-setup
+  setup-depends: base, Cabal, cpphs, directory, filepath, process, template-haskell, text


### PR DESCRIPTION
This is needed for `cabal new-build` and should also help for the normal builds if the deps are not already installed.

It is only supported by `cabal ≥ 1.24` but the section will be ignored by older versions (although there is a warning) so adding it shouldn’t break the build for anyone.
